### PR TITLE
Pb 6

### DIFF
--- a/src/main/java/onboarding/Problem6.java
+++ b/src/main/java/onboarding/Problem6.java
@@ -19,11 +19,13 @@ public class Problem6 {
         }
     }
 
-    public static void addEmail(Set<Integer> set, List<Integer> wordIdx, List<String> answer, List<List<String>> forms) {
+    public static void addEmail(Set<Integer> set, List<Integer> wordIdx, Set<String> emailSet, List<List<String>> forms) {
+        String emailTmp;
         for (int idx : wordIdx) {
-            if (!set.contains(idx)) {
+            emailTmp = forms.get(idx).get(0);
+            if (!set.contains(idx) && emailTmp.contains("email.com")) {
                 set.add(idx);
-                answer.add(forms.get(idx).get(0));
+                emailSet.add(forms.get(idx).get(0));
             }
         }
     }
@@ -33,6 +35,7 @@ public class Problem6 {
         // 0 <= 닉네임에서 도출될 수 있는 단어 조합 <= 19
         List<String> answer = new ArrayList<>();
         Set<Integer> set = new HashSet<>();
+        Set<String> emailSet = new HashSet<>();
         HashMap<String, List<Integer>> word = new HashMap<>();
         StringBuilder name = new StringBuilder();
 
@@ -56,10 +59,11 @@ public class Problem6 {
             if (word.get(key).size() == 1) {
                 continue;
             }
-            addEmail(set, word.get(key), answer, forms);
+            addEmail(set, word.get(key), emailSet, forms);
         }
 
         // answer 정렬
+        answer = new ArrayList<>(emailSet);
         answer.sort(Comparator.naturalOrder());
 
         return answer;

--- a/src/main/java/onboarding/Problem6.java
+++ b/src/main/java/onboarding/Problem6.java
@@ -1,10 +1,67 @@
 package onboarding;
 
-import java.util.List;
+import java.util.*;
 
 public class Problem6 {
+
+    public static void checkAllCombination(StringBuilder name, HashMap<String, List<Integer>> word, int wordIdx) {
+        String tmp;
+
+        for (int i = 0; i < name.length()-1; i++) {
+            tmp = name.substring(i, i+2);
+            if (word.containsKey(tmp)) {
+                word.get(tmp).add(wordIdx);
+            }
+            else {
+                word.put(tmp, new ArrayList<Integer>());
+                word.get(tmp).add(wordIdx);
+            }
+        }
+    }
+
+    public static void addEmail(Set<Integer> set, List<Integer> wordIdx, List<String> answer, List<List<String>> forms) {
+        for (int idx : wordIdx) {
+            if (!set.contains(idx)) {
+                set.add(idx);
+                answer.add(forms.get(idx).get(0));
+            }
+        }
+    }
+
     public static List<String> solution(List<List<String>> forms) {
-        List<String> answer = List.of("answer");
+        // 1 <= forms.size() <= 10,000
+        // 0 <= 닉네임에서 도출될 수 있는 단어 조합 <= 19
+        List<String> answer = new ArrayList<>();
+        Set<Integer> set = new HashSet<>();
+        HashMap<String, List<Integer>> word = new HashMap<>();
+        StringBuilder name = new StringBuilder();
+
+        for (int i = 0; i < forms.size(); i++) {
+            name.append(forms.get(i).get(1));
+
+            // 닉네임이 1글자인 경우는 중복이 일어날 수 없음
+            if (name.length() == 1) {
+                continue;
+            }
+            else {
+                // 닉네임에서 일어날 수 있는 모든 경우의 수를 확인 최대 19개
+                checkAllCombination(name, word, i);
+            }
+            //StringBuilder 초기화
+            name.setLength(0);
+        }
+
+        // 중복되는 2자리 단어가 존재하는 forms의 index를 확인하고 해당 index의 email을 answer에 추가
+        for (String key : word.keySet()) {
+            if (word.get(key).size() == 1) {
+                continue;
+            }
+            addEmail(set, word.get(key), answer, forms);
+        }
+
+        // answer 정렬
+        answer.sort(Comparator.naturalOrder());
+
         return answer;
     }
 }


### PR DESCRIPTION
### 요구사항
- 신청받은 닉네임 중 같은 글자가 연속적으로 포함 되는 닉네임을 작성한 지원자의 이메일 목록을 return 하도록 solution 메서드를 완성하라.
    > 모든 닉네임을 순회하며 가능한 조합의 단어를 생성 및 포함하는 크루원의 index를 add
    > 단어가 포함되는 index의 크기가 2 이상인 경우 해당 index의 email을 set에 add
    > set를 리스트로 변환 후 오름차순 정렬

### 제한사항
- 두 글자 이상의 문자가 연속적으로 순서에 맞추어 포함되어 있는 경우 중복으로 간주한다.
    > 반영 완료
- 크루는 1명 이상 10,000명 이하이다.
    > forms를 순회할 때 O(10000)
- 이메일은 이메일 형식에 부합하며, 전체 길이는 11자 이상 20자 미만이다.
    > String 타입
- 신청할 수 있는 이메일은 email.com 도메인으로만 제한한다.
    > 예외처리 완료
- 닉네임은 한글만 가능하고 전체 길이는 1자 이상 20자 미만이다.
    > 반영 완료
- result는 이메일에 해당하는 부분의 문자열을 오름차순으로 정렬하고 중복은 제거한다.
    > 반영 완료